### PR TITLE
Bugfix/Missing relations error handling

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -124,9 +124,18 @@ export const mapRelations = (entities, relations, files) => {
 
             // Same in reverse (each "Many" gets a "One")
             mappedEntities[cm] = mappedEntities[cm].map(entity => {
+                const targetEntity = mappedEntities[co].find(e => e.directusId === entity[fm]);
+                if (!targetEntity) {
+                    warn(
+                        `Could not find an ManyToOne match in ${co} for item in ${cm} ` +
+                            `with id ${entity.directusId}. The field will be left null.`,
+                    );
+                    return entity;
+                }
+
                 const newEntity = {
                     ...entity,
-                    [`${fm}___NODE`]: mappedEntities[co].find(e => e.directusId === entity[fm]).id,
+                    [`${fm}___NODE`]: targetEntity.id,
                 };
                 delete newEntity[fm];
                 return newEntity;

--- a/src/process.js
+++ b/src/process.js
@@ -108,10 +108,28 @@ export const mapRelations = (entities, relations, files) => {
         if (relation.junction_field === null) {
             // Many-to-one, build the relation right away
             const co = relation.collection_one;
-            const fo = relation.field_one;
+            let fo = relation.field_one;
             const cm = relation.collection_many;
-            const fm = relation.field_many;
+            let fm = relation.field_many;
             info(`Found One-To-Many relation: ${co} -> ${cm}`);
+
+            // If the relation hasn't been defined in both collections, fall back
+            // to using the name of the related collection instead of the relation
+            // field
+            if (!fo) {
+                warn(
+                    `Missing OneToMany-relation in ${co}. The relation ` +
+                        `will be called ${cm} in GraphQL as a best guess.`,
+                );
+                fo = cm;
+            }
+            if (!fm) {
+                warn(
+                    `Missing ManyToOne-relation in ${cm}. The relation ` +
+                        `will be called ${co} in GraphQL as a best guess.`,
+                );
+                fm = co;
+            }
 
             // Replace each "One" entity with one that contains relations
             // to "Many" entities


### PR DESCRIPTION
This is a fix for the issue in #3 where Gatsby build would fail if Directus contained a Many-To-One relation in an item where the relation was left empty. New behavior is to warn the user on build and set the field to `null`, but not crash the whole build.

Another improvement found along the way is to try and fall back to using a collection name for a relation which is missing a field. For example, when a user follows the `directors->movies` Many-To-One relation setup as described [here](https://docs.directus.io/guides/relationships.html#many-to-one) without setting up the One-To-Many, before this PR there would be a `null` field containing the right data, now it would be named `movies` for the collection name it refers to.