### PR TITLE
Bugfix/Broken relations error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-directus7",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-source-directus7",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Source plugin for Gatsby to fetch data from Directus Headless CMS",
     "author": "Joonas Palosuo <joonas.palosuo@gmail.com>",
     "license": "MIT",

--- a/src/process.js
+++ b/src/process.js
@@ -118,14 +118,14 @@ export const mapRelations = (entities, relations, files) => {
             // field
             if (!fo) {
                 warn(
-                    `Missing OneToMany-relation in ${co}. The relation ` +
+                    `Missing One-To-Many-relation in ${co}. The relation ` +
                         `will be called ${cm} in GraphQL as a best guess.`,
                 );
                 fo = cm;
             }
             if (!fm) {
                 warn(
-                    `Missing ManyToOne-relation in ${cm}. The relation ` +
+                    `Missing Many-To-One-relation in ${cm}. The relation ` +
                         `will be called ${co} in GraphQL as a best guess.`,
                 );
                 fm = co;
@@ -145,8 +145,8 @@ export const mapRelations = (entities, relations, files) => {
                 const targetEntity = mappedEntities[co].find(e => e.directusId === entity[fm]);
                 if (!targetEntity) {
                     warn(
-                        `Could not find an ManyToOne match in ${co} for item in ${cm} ` +
-                            `with id ${entity.directusId}. The field will be left null.`,
+                        `Could not find an Many-To-One match in ${co} for item in ${cm} ` +
+                            `with id ${entity.directusId}. The field value will be left null.`,
                     );
                     return entity;
                 }


### PR DESCRIPTION
This PR readdresses issues described in #3 and partially fixed in #4 regarding build failing with Directus configurations that aren't exactly right configured with the first try. Directus has a bad habit of leaving dangling and semi-broken items in its `directus_relations` which this plugin didn't handle gracefully. Added warnings and falling back to `null`s should alleviate the problems.