### PR TITLE
Feature: Filtering items by status and include only those with matching status as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ module.exports = {
          */
         email: 'example@directususer.com',
         password: 'password123',
+        /**
+         * Optional - set the status of the items you want to receive. E.g. if you functionality
+         * want to receive items with status 'published'.
+         * `targetStatus` sets the status you want the items to have. `defaultStatus`
+         * defines a fallback status that will also be accepted (e.g. you want
+         * items with status 'draft', but 'published' is also acceptable)
+         *
+         */
+        targetStatus: 'draft',
+        defaultStatus: 'published'
       },
     },
   ],

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,14 +1,16 @@
 import DirectusSDK from '@directus/sdk-js';
-import { error } from './process';
+import { info, warn, error } from './process';
 
 /**
  * Class with methods for fetching data from Directus
  * via their JS SDK
  */
 export default class DirectusFetcher {
-    constructor(url, project, email, password) {
+    constructor(url, project, email, password, targetStatus, defaultStatus) {
         this.email = email;
         this.password = password;
+        this.targetStatus = targetStatus;
+        this.defaultStatus = defaultStatus;
         try {
             this.client = new DirectusSDK({
                 url,
@@ -72,7 +74,7 @@ export default class DirectusFetcher {
                 } catch (e) {
                     error(`Error fetching entities for Collection ${collectionName}: `, e);
                 }
-            }),
+            }, this),
         );
         return entities;
     }
@@ -99,7 +101,50 @@ export default class DirectusFetcher {
     async getItemsForCollection(collectionName) {
         try {
             const itemsData = await this.client.getItems(collectionName, { limit: '-1' });
-            return itemsData.data;
+
+            if(!this.targetStatus) {
+              return itemsData.data;
+            } else {
+              // go through all items in collection to check against target status
+              const checkedItems = await Promise.all(
+                itemsData.data.map(async item => {
+                  if(item.status === this.targetStatus || (this.defaultStatus ? item.status === this.defaultStatus : false)){
+                    info(`Status matched for ${collectionName} ${item.id}. Using item`)
+                    return item;
+                  } else {
+                    info(`Target status not matched for ${collectionName} ${item.id}. Going through revisions`)
+                    // get all revisions
+                    const itemRevisions = await this.client.getItemRevisions(collectionName, item.id);
+
+                    // go through all revisions and get the newest matching the target status
+                    const selectedItem = itemRevisions.data.reduce((selectedItem, currentItem) => {
+                      if(currentItem.data.status === this.targetStatus && selectedItem.data.modified_on < currentItem.data.modified_on){
+                        return currentItem;
+                      } else {
+                        return selectedItem;
+                      }
+                    })
+                    if(selectedItem.data.status === this.targetStatus) {
+                      // workaround: the number fields in the JSON returned from getItemRevisions are Strings, need to convert
+                      Object.keys(selectedItem.data).forEach(field => {
+                        const converted = Number(selectedItem.data[field]);
+                        if(!isNaN(converted)) {
+                          selectedItem.data[field] = converted;
+                        }
+                      });
+                      info(`Revision found that matches target status ${this.targetStatus} in ${collectionName} item ${item.id}`)
+                      return selectedItem.data;
+                    } else {
+                      warn(`No item of ${item.id} in ${collectionName} matched target status ${this.targetStatus}. This might lead to unexpected behavior!`)
+                      return false;
+                    }
+                  }
+                })
+              )
+
+              // remove all items that didn't match the target status
+              return checkedItems.filter(item => {return item !== false});
+            }
         } catch (e) {
             error(`Error while fetching collection ${collectionName}: `, e);
             return [];

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -14,14 +14,15 @@ import {
 
 exports.sourceNodes = async (
     { actions, store, cache, createNodeId },
-    { url, project, email, password },
+    { url, project, email, password, targetStatus, defaultStatus },
 ) => {
     const { createNode } = actions;
 
     info('Directus Data Fetcher initializing...');
+    info(`targetStatus is: ${targetStatus} `)
     let fetcher;
     try {
-        fetcher = new Fetcher(url, project, email, password);
+        fetcher = new Fetcher(url, project, email, password, targetStatus, defaultStatus);
         success('Connected to Directus!');
     } catch (e) {
         info('Failed to initialize Directus connection. Please check your gatsby-config.js');

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -19,7 +19,7 @@ exports.sourceNodes = async (
     const { createNode } = actions;
 
     info('Directus Data Fetcher initializing...');
-    info(`targetStatus is: ${targetStatus} `)
+    info(`targetStatus is: ${targetStatus} `);
     let fetcher;
     try {
         fetcher = new Fetcher(url, project, email, password, targetStatus, defaultStatus);


### PR DESCRIPTION
We required to only include for example published items as source for a gatsby build. Hence I included two parameters for filtering:

- targetStatus: items having this status should be included
- defaultStatus: items with this status can also be included, if newer than the latest with the target status (for example you want to build a draft site, but this can also include the newer published version of an item)

The purpose of this is to have on gatsby build for a (private) staging site, while only items that are marked as 'published' go to the public site.